### PR TITLE
sort and merge CIDR ranges using netaddr gem

### DIFF
--- a/lib/unspam/cli.rb
+++ b/lib/unspam/cli.rb
@@ -2,6 +2,7 @@ require 'thor'
 require 'json'
 require 'httparty'
 require 'ipaddr'
+require 'netaddr'
 
 module Unspam
   class CLI < Thor
@@ -40,7 +41,12 @@ module Unspam
         response = HTTParty.get "https://stat.ripe.net/data/announced-prefixes/data.json?resource=#{asn}&min_peers_seeing=1"
         result = JSON.parse(response.body)
 
-        result['data']['prefixes'].map { |h| h['prefix'] }.sort.each do |prefix|
+        prefixes = Array.new
+        result['data']['prefixes'].map { |h| h['prefix'] }.each do |prefix|
+          prefixes.push(prefix)
+        end
+
+        NetAddr.merge(prefixes.map{ |ip| NetAddr::CIDR.create(ip) }, :Short => true).each do |prefix|
           printf("%-25s%5s\n", prefix, @msg)
         end
       end

--- a/unspam.gemspec
+++ b/unspam.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'thor'
   spec.add_dependency 'httparty'
+  spec.add_dependency 'netaddr'
 
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
Where and AS makes announcements are made for many separate CIDR ranges, the NetAddr gem can be used to find the most efficient CIDR mapping (without creating "new" networks), and will also output in a "natural sort" order.
