### PR TITLE
Remove redundant subnets from output

### DIFF
--- a/lib/unspam/cli.rb
+++ b/lib/unspam/cli.rb
@@ -46,7 +46,8 @@ module Unspam
           prefixes.push(prefix)
         end
 
-        NetAddr.merge(prefixes.map{ |ip| NetAddr::CIDR.create(ip) }, :Short => true).each do |prefix|
+        supernets = NetAddr.supernets(prefixes.map{ |ip| NetAddr::CIDR.create(ip) })
+        NetAddr.merge(supernets, :Short => true).each do |prefix|
           printf("%-25s%5s\n", prefix, @msg)
         end
       end


### PR DESCRIPTION
Currently smaller subnets "10.0.0.1/32" will also be returned as well as their supernets - which is redundant for this use.  Before merging, use `NetAddr.supernets` to discard the more precise subnets.
